### PR TITLE
Fixed notes being handled once per card

### DIFF
--- a/mergenotes.py
+++ b/mergenotes.py
@@ -95,10 +95,16 @@ def append(note1: Note, note2: Note) -> None:
 def merge_cards_fields(cids: Collection) -> None:
     cards = [mw.col.getCard(cid) for cid in cids]
     cards = sorted(cards, key=OrderingChoices.get_key(config['ordering']), reverse=config['reverse_order'])
-    notes = [card.note() for card in cards]
+    
+    # Include notes only once
+    notes = []
+    for card in cards:
+        note = card.note()
+        if note.id not in [n.id for n in notes]:
+            notes.append(note)
 
     # Iterate till 1st element and keep on decrementing i
-    for i in reversed(range(len(cids) - 1)):
+    for i in reversed(range(len(notes) - 1)):
         append(notes[i], notes[i + 1])
 
     if config['delete_original_notes'] is True:


### PR DESCRIPTION
When multiple cards are selected, in `merge_cards_fields` notes are handled for each card of that note, instead of each note being handled once.

This results in duplicate merging, and, more importantly, _all_ notes ending up deleted if "Delete original notes" is enabled, instead of one note remaining.

This is only for the old branch, since I'm on Anki 2.1.35, I haven't checked if the same issue exists on the new branch.