### PR TITLE
Fixes AttributeError for QDialogButtonBox error

### DIFF
--- a/merge_duplicates.py
+++ b/merge_duplicates.py
@@ -68,7 +68,7 @@ def append_merge_duplicates_button(self: FindDuplicatesDialog, dupes: list[tuple
     self._dupes = dupes
     if not getattr(self, '_merge_dupes_button', None):
         self._merge_dupes_button = b = self.form.buttonBox.addButton(
-            MergeDupes.action_name, QDialogButtonBox.ActionRole
+            MergeDupes.action_name, QDialogButtonBox.ButtonRole.ActionRole
         )
         qconnect(b.clicked, lambda: merge_dupes(parent=self, dupes=self._dupes))
 


### PR DESCRIPTION
Occured after updating to Anki 23.10rc1
When searching for duplicate notes the following error message shows and the merge duplicates button is missing.
This is fixed by adding `.ButtonRole` to `QDialogButtonBox.ActionRole` -> `QDialogButtonBox.ButtonRole.ActionRole`

> Anki 23.10 (3394ab02) Python 3.9.15 Qt 6.5.3 PyQt 6.5.3
> Platform: Windows-10-10.0.23570
> Flags: frz=True ao=True sv=3
> Add-ons, last update check: 2023-10-24 04:13:26
> Add-ons possibly involved: ⁨AJT Merge Notes⁩
>
> Caught exception:
> Traceback (most recent call last):
>   File "aqt.taskman", line 138, in _on_closures_pending
>   File "aqt.taskman", line 82, in <lambda>
>   File "aqt.operations", line 260, in wrapped_done
>   File "decorator", line 232, in fun
>   File "anki.hooks", line 89, in decorator_wrapper
>   File "anki.hooks", line 81, in repl
>   File "C:\Users\ ... \AppData\Roaming\Anki2\addons21\1425504015\merge_duplicates.py", line 71, in append_merge_duplicates_button
>     MergeDupes.action_name, QDialogButtonBox.ActionRole
> AttributeError: type object 'QDialogButtonBox' has no attribute 'ActionRole'